### PR TITLE
Updated to   - Mapbox-iOS-SDK (3.0.1)   (paths and styleURLs)

### DIFF
--- a/Station.h
+++ b/Station.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "Mapbox.h"
+#import "Mapbox/Mapbox.h"
 
 @interface Station : NSObject <MGLAnnotation>
 

--- a/StationFinderRevised/ViewController.m
+++ b/StationFinderRevised/ViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "ViewController.h"
-#import "Mapbox.h"
+#import "Mapbox/Mapbox.h"
 #import "Station.h"
 #import "WebViewController.h"
 #import "StationDotsView.h"
@@ -28,8 +28,7 @@
     [super viewDidLoad];
    
     //  set style to Emerald and initizalize Mapbox mapview and
-    NSURL *styleURL = [NSURL URLWithString:@"asset://styles/emerald-v8.json"];
-    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:styleURL];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle emeraldStyleURL]];
     
     //self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;


### PR DESCRIPTION
Updating your Station Finder code base to latest SDK (3.0.1).  Mostly header paths and the renaming of the style URL for Emerald.

I left out the `Podfile.lock`, but it changed as well after a call to `pod update`.
